### PR TITLE
Implement tag page

### DIFF
--- a/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -49,7 +49,7 @@ export const InfiniteScroll: React.FC<InfiniteScrollProps> = ({
 
     if (
       hasMore &&
-      wardRef.current!.getBoundingClientRect().top - window.innerHeight <
+      wardRef?.current!.getBoundingClientRect().top - window.innerHeight <
         threshold!
     ) {
       onLoadMore();

--- a/src/components/Layouts/SiteLayout.tsx
+++ b/src/components/Layouts/SiteLayout.tsx
@@ -2,19 +2,9 @@ import React, { FC } from 'react';
 
 import { MenuBar } from '@components/MenuBar';
 import { Container } from '@components/Ui';
-import { styled, media } from '@styles/styled';
-import { SiteTheme } from '@types-app';
+import { styled } from '@styles/styled';
 
-const Main = styled(Container)`
-  && {
-    padding-top: ${({ theme }) => `calc(35px + ${theme.sizes.menuBar.height})`};
-
-    ${media.greaterThan('medium')`
-      padding-top: ${({ theme }: { theme: SiteTheme }) =>
-        `calc(35px + ${theme.sizes.menuBar.height})`};
-    `}
-  }
-`;
+const Main = styled(Container)``;
 
 // TODO: couldn't find something better for any
 export const SiteLayout: FC<{ as?: any }> = ({ children, ...props }) => {

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -15,14 +15,32 @@ import {
 } from './styled';
 import { PostModel } from '@models/Post';
 import { PostApiData } from 'src/types/api/posts';
+import { getTagUrl } from '@utils/url';
 
 type PostCardProps = {
   post: PostModel;
   tags?: PostApiData['post_tags'];
 };
 
-export const PostCard: React.FC<PostCardProps> = ({ post, tags }) => {
-  const { featured_image, title, subtitle, date, postUri } = post!;
+export const PostCard: React.FC<PostCardProps> = ({ post }) => {
+  const { featured_image, title, subtitle, date, postUri, post_tags } = post!;
+
+  /**
+   * For the tags, every post only has the tags id.
+   * Which is not the case for home page where we have an array of tag objects
+   * with all tag info.
+   */
+  const shouldRenderTag =
+    isNotNilNorEmpty(post_tags) && typeof post_tags[0] !== 'string';
+
+  const tags = shouldRenderTag ? (
+    <Tags>
+      {post_tags!.map((tag) => {
+        const { id, name, slug } = tag!;
+        return <Tag key={id} tag={name!} slug={getTagUrl(slug)} />;
+      })}
+    </Tags>
+  ) : null;
 
   return (
     <PostCardWrapper>
@@ -49,14 +67,7 @@ export const PostCard: React.FC<PostCardProps> = ({ post, tags }) => {
           </time>
         </DateAndTime>
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
-        {isNotNilNorEmpty(tags) && (
-          <Tags>
-            {tags!.map((tag) => {
-              const { id, name, slug } = tag!;
-              return <Tag key={id} tag={name!} slug={slug!} />;
-            })}
-          </Tags>
-        )}
+        {tags}
       </Body>
     </PostCardWrapper>
   );

--- a/src/components/SEO/index.ts
+++ b/src/components/SEO/index.ts
@@ -1,1 +1,2 @@
 export * from './SEO';
+export * from './utils';

--- a/src/components/SEO/utils.ts
+++ b/src/components/SEO/utils.ts
@@ -1,0 +1,3 @@
+export function titleWithNameAndJobTitle(title: string): string {
+  return `${title} | Raul Melo Software Developer`;
+}

--- a/src/pages/tag/[slug].tsx
+++ b/src/pages/tag/[slug].tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { GetStaticPaths } from 'next';
+import head from 'ramda/src/head';
+
+import { Backend } from '@services/Backend';
+import {
+  PersonalInformationApiData,
+  PostsTagApiData,
+  SiteApiData,
+  SocialApiData,
+} from '@types-api';
+import { TagPage, TagPageProps } from '@screens/Tag/TagPage';
+
+const Tag = ({ tag, personalInfo, social, site }: TagPageProps) => {
+  return (
+    <TagPage
+      tag={tag}
+      personalInfo={personalInfo}
+      social={social}
+      site={site}
+    />
+  );
+};
+
+type Params = {
+  params: {
+    slug: string;
+  };
+};
+
+export const getStaticProps = async ({ params }: Params) => {
+  const [tags, personalInfo, social, site]: [
+    PostsTagApiData,
+    PersonalInformationApiData,
+    SocialApiData,
+    SiteApiData,
+  ] = await Promise.all([
+    Backend.fetch('post-tags', `?slug=${params.slug}`),
+    Backend.fetch('personal-information'),
+    Backend.fetch('social'),
+    Backend.fetch('site'),
+  ]);
+
+  const tag = head(tags);
+
+  return {
+    props: { tag, personalInfo, social, site },
+    revalidate: 1,
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const tags = (await Backend.fetch('post-tags')) as PostsTagApiData;
+
+  const paths = tags.map((tag) => ({
+    params: {
+      slug: tag['slug'],
+    },
+  }));
+
+  return {
+    paths,
+    fallback: true,
+  };
+};
+
+export default Tag;

--- a/src/pages/tag/[slug].tsx
+++ b/src/pages/tag/[slug].tsx
@@ -10,6 +10,7 @@ import {
   SocialApiData,
 } from '@types-api';
 import { TagPage, TagPageProps } from '@screens/Tag/TagPage';
+import { SupportedLanguages } from '@types-app';
 
 const Tag = ({ tag, personalInfo, social, site }: TagPageProps) => {
   return (
@@ -26,6 +27,7 @@ type Params = {
   params: {
     slug: string;
   };
+  locale: SupportedLanguages;
 };
 
 export const getStaticProps = async ({ params }: Params) => {
@@ -52,15 +54,34 @@ export const getStaticProps = async ({ params }: Params) => {
 export const getStaticPaths: GetStaticPaths = async () => {
   const tags = (await Backend.fetch('post-tags')) as PostsTagApiData;
 
-  const paths = tags.map((tag) => ({
-    params: {
-      slug: tag['slug'],
-    },
-  }));
+  const paths: Params[] = [];
+
+  /**
+   * Without this generation, when I'm in `/tag/css` for instance
+   * and want to access `/pt/tag/css`, it'll redirect to a 404 page.
+   *
+   * If I switch "fallback" to true, the problem will be fixed only locally
+   * or running in server (not in serverless) and it'll also leads in the first
+   * render of TagPage having "tag" prop as undefined.
+   *
+   * In this way I generate the same page for both lang and I don't have to do
+   * any workaround.
+   */
+
+  ['en', 'pt'].forEach((lang) => {
+    tags.forEach((tag) => {
+      paths.push({
+        params: {
+          slug: tag.slug,
+        },
+        locale: lang as SupportedLanguages,
+      });
+    });
+  });
 
   return {
     paths,
-    fallback: true,
+    fallback: false,
   };
 };
 

--- a/src/screens/Blog/BlogPage.tsx
+++ b/src/screens/Blog/BlogPage.tsx
@@ -72,7 +72,6 @@ export const BlogPage: React.FC<BlogPageProps> = ({
         siteUrl={site.url}
         imageUrl={featured_image.url}
         twitterUrl={social.twitter.url}
-        withDefaultTitle
         title={post.title}
         description={post.description}
         /* TODO: fix that 

--- a/src/screens/Home/components/Posts.tsx
+++ b/src/screens/Home/components/Posts.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as R from 'ramda';
+import isEmpty from 'ramda/src/isEmpty';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -88,7 +88,7 @@ export const Posts: React.FC<PostsProps> = ({
         {customTitle || <FormattedMessage id={filterLocale[filter]} />}
       </PostsTitle>
 
-      {R.isEmpty(posts) ? (
+      {isEmpty(posts) ? (
         <NoPostsMessage>
           <FormattedMessage
             id="home.noPosts"
@@ -119,7 +119,7 @@ export const Posts: React.FC<PostsProps> = ({
                   },
                 }}
               >
-                <PostCard post={post} tags={post.post_tags} />
+                <PostCard post={post} key={post.id} />
               </PostListItem>
             ))}
           </AnimatePresence>

--- a/src/screens/Tag/TagPage.tsx
+++ b/src/screens/Tag/TagPage.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { AppThemeProvider } from '@contexts/AppTheme';
+import { GlobalStyles } from '@styles/index';
+import { MenuBar } from '@components/MenuBar';
+import { AuthorPresentation } from '@screens/Home/components/AuthorPresentation';
+import { Container } from '@components/Ui';
+import { SEO, titleWithNameAndJobTitle } from '@components/SEO';
+import { useLocalization } from '@hooks/useLocalization';
+import { Posts } from '@screens/Home/components/Posts';
+import { useBlogPostFilters } from '@screens/Home/hooks/useBlogPostFilters';
+import { getTagUrl } from '@utils/url';
+import {
+  PersonalInformationApiData,
+  PostTagApiData,
+  SiteApiData,
+  SocialApiData,
+} from '@types-api';
+
+const messages = defineMessages({
+  description: {
+    id: 'tag.description',
+  },
+  title: {
+    id: 'tag.title',
+  },
+});
+
+export type TagPageProps = {
+  tag: PostTagApiData;
+  personalInfo: PersonalInformationApiData;
+  social: SocialApiData;
+  site: SiteApiData;
+};
+
+export const TagPage: React.FC<TagPageProps> = ({
+  tag,
+  personalInfo,
+  social,
+  site,
+}) => {
+  const { formatMessage, locale } = useLocalization();
+  const {
+    activeFilter,
+    loadMorePosts,
+    postsToRender,
+    hasMore,
+  } = useBlogPostFilters(tag.blog_posts);
+
+  return (
+    <>
+      <SEO
+        /* TODO: centralize a single way to do that
+      currently "withDefaultTitle" does something similar 
+      */
+        description={titleWithNameAndJobTitle(
+          formatMessage(messages.description, { tag: tag.name }),
+        )}
+        title={formatMessage(messages.title, { tag: tag.name })}
+        withDefaultTitle
+        siteUrl={site.url}
+        imageUrl={site.seo_image.url}
+        twitterUrl={social.twitter.url}
+        url={getTagUrl(tag.slug)}
+      />
+      <AppThemeProvider>
+        <GlobalStyles />
+        <MenuBar />
+        <Container as="main">
+          <AuthorPresentation
+            fullName={personalInfo.full_name}
+            profilePic={personalInfo.profile_pic.url}
+            linkedIn={social.linkedIn}
+            github={social.github}
+            twitter={social.twitter}
+          />
+          <Posts
+            posts={postsToRender(locale)}
+            filter={activeFilter}
+            hasMore={hasMore()}
+            loadMore={loadMorePosts}
+            customTitle={formatMessage(messages.title, { tag: tag.name })}
+          />
+        </Container>
+      </AppThemeProvider>
+    </>
+  );
+};

--- a/src/styles/globals.ts
+++ b/src/styles/globals.ts
@@ -1,4 +1,4 @@
-import { css } from '@styles/styled';
+import { css, media } from '@styles/styled';
 
 export const themeBackgroundColor = {
   dark: 'rgb(21, 32, 43)',
@@ -56,6 +56,15 @@ export const customGlobals = css`
 
     transition: background-color 0.2s ease, color 0.2s ease, fill 0.2s ease,
       opacity 0.2s ease, color 0.2s ease, border 0.2s ease;
+  }
+
+  #__next {
+    padding-top: ${({ theme }) => `calc(35px + ${theme.sizes.menuBar.height})`};
+
+    ${media.greaterThan('medium')`
+      padding-top: ${({ theme }) =>
+        `calc(35px + ${theme.sizes.menuBar.height})`};
+    `}
   }
 
   img,

--- a/src/types/api/endpoints.ts
+++ b/src/types/api/endpoints.ts
@@ -5,4 +5,5 @@ export type Endpoints =
   | 'site'
   | 'uses'
   | 'posts'
-  | 'post-series';
+  | 'post-series'
+  | 'post-tags';

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -6,3 +6,4 @@ export * from './endpoints';
 export * from './uses';
 export * from './posts';
 export * from './post-series';
+export * from './post-tags';

--- a/src/types/api/post-tags.ts
+++ b/src/types/api/post-tags.ts
@@ -1,0 +1,15 @@
+import { PostsApiData } from './posts';
+
+export interface PostTagApiData {
+  _id: string;
+  tag: string;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
+  slug: string;
+  name: string;
+  id: string;
+  blog_posts: PostsApiData;
+}
+
+export type PostsTagApiData = PostTagApiData[];

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,7 @@
+export function getPostUrl(postSlug: string) {
+  return `/blog/${postSlug}`;
+}
+
+export function getTagUrl(tagSlug: string) {
+  return `/tag/${tagSlug}`;
+}


### PR DESCRIPTION
# Description

This PR introduces Tag page `/tag/front-end`. 

The only missing information in that is the tags in the post. This is due a API limitation, where when we fetch a tag, the post inside the tag only has its tags id instead an object.