### PR TITLE
Fix Overlay z-index

### DIFF
--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useLocalization } from '@hooks/useLocalization';
 import { useApp } from '@hooks/useApp';
 import { isBrowserApiAvailable } from '@utils/utilities';
-import { Nav, StyledLink, OpacityLayer } from './styles';
+import { Nav, StyledLink, Overlay } from './styles';
 
 const messages = defineMessage({
   home: {
@@ -94,7 +94,7 @@ export const SideMenu = () => {
         })}
       </Nav>
       {!isCollapsed ? (
-        <OpacityLayer
+        <Overlay
           style={{
             pointerEvents: isCollapsed ? 'none' : 'all',
           }}

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -93,21 +93,23 @@ export const SideMenu = () => {
           );
         })}
       </Nav>
-      <OpacityLayer
-        style={{
-          pointerEvents: isCollapsed ? 'none' : 'all',
-        }}
-        onClick={hide}
-        animate={animate}
-        variants={{
-          open: {
-            opacity: 1,
-          },
-          closed: {
-            opacity: 0,
-          },
-        }}
-      />
+      {!isCollapsed ? (
+        <OpacityLayer
+          style={{
+            pointerEvents: isCollapsed ? 'none' : 'all',
+          }}
+          onClick={hide}
+          animate={animate}
+          variants={{
+            open: {
+              opacity: 1,
+            },
+            closed: {
+              opacity: 0,
+            },
+          }}
+        />
+      ) : null}
     </>
   );
 };

--- a/src/components/SideMenu/styles.ts
+++ b/src/components/SideMenu/styles.ts
@@ -12,7 +12,7 @@ export const Nav = styled(motion.nav)<{ isCollapsed: boolean }>`
   background-color: ${({ theme }) => theme.color.background};
   padding: 8px 0;
   overflow-x: hidden;
-  z-index: 2;
+  z-index: 3;
   display: flex;
   flex-direction: column;
   border: ${({ theme }) =>
@@ -50,5 +50,5 @@ export const OpacityLayer = styled(motion.div)`
   right: 0;
   left: 0;
   background-color: rgba(0, 0, 0, 0.8);
-  z-index: 1;
+  z-index: 2;
 `;

--- a/src/components/SideMenu/styles.ts
+++ b/src/components/SideMenu/styles.ts
@@ -42,7 +42,7 @@ export const StyledLink = styled.a<{ $isCurrentPage?: boolean }>`
     `}
 `;
 
-export const OpacityLayer = styled(motion.div)`
+export const Overlay = styled(motion.div)`
   position: absolute;
   opacity: 0;
   top: 0;


### PR DESCRIPTION
Closes #19 

# Description

This PR fixes the z-index problem when the Overlay shows up in a page which contains PostCard.

It also: 
- rename the component from `OpacityLayer` to `Overlay` for a more standard name;
- change its behavior avoiding to render it when menu is collapsed (unnecessary dom element)

# Screenshot
![Sizzy-MacBook Air localhost 13Nov 07 55](https://user-images.githubusercontent.com/12464600/99038323-93792400-2585-11eb-8a7d-9c3d23506f2e.png)
