### PR TITLE
feat(cv): add different style for 1440px

### DIFF
--- a/src/pages/cv.tsx
+++ b/src/pages/cv.tsx
@@ -23,8 +23,9 @@ const CurriculumPage = () => {
         <article
           className={classNames([
             'container',
-            'mx-auto max-w-screen-md',
+            'mx-auto max-w-screen-md 1/5xl:max-w-screen-xl 2xl:max-w-max',
             'pt-6 sm:pt-4',
+            '1/5xl:grid 1/5xl:grid-cols-3 1/5xl:gap-6',
           ])}
         >
           <header className="mb-8 pt-14 md:pt-5 px-4 md:px-0">
@@ -57,7 +58,7 @@ const CurriculumPage = () => {
             </p>
           </header>
 
-          <main className="pb-6">
+          <main className="pb-6 1/5xl:col-span-2">
             <iframe
               src="https://docs.google.com/document/d/e/2PACX-1vRH5F5mV58PwToU2intAbHK7XujvdPyOhWr2gDdCC9YcisCSaJVctuGlzE_28zgEbJt4qEo-CUJl-hb/pub?embedded=true"
               className="max-h-full w-full shadow-xl"
@@ -82,6 +83,15 @@ const CurriculumPage = () => {
 
         .iframe-container iframe {
           height: 75vh;
+        }
+
+        @media (max-width: 1440px) {
+        }
+
+        @media (min-width: 1440px) {
+          .iframe-container iframe {
+            height: 95vh;
+          }
         }
       `}</style>
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       screens: {
         print: { raw: 'print' },
+        '1/5xl': '1440px',
       },
       transitionProperty: {
         spacing: 'margin, padding',


### PR DESCRIPTION
Since often people are looking cvs on PC, it makes sense having a bit better experience on at. So for screens larger than 1440px, I present text and CV side-by-side.

**1440px screen**
![Sizzy-MacBook Air localhost 23Jan 09 18](https://user-images.githubusercontent.com/12464600/105573194-1d025a80-5d5c-11eb-885c-b1a1173dc642.png)

**1920px screen**
![Sizzy-Desktop localhost 23Jan 09 18](https://user-images.githubusercontent.com/12464600/105573192-1c69c400-5d5c-11eb-849f-ed044c32c879.png)


> Obs.: this won't after smaller screens:

**1194px screen**
![Sizzy-iPad Pro 11 localhost 23Jan 09 18](https://user-images.githubusercontent.com/12464600/105573188-1b389700-5d5c-11eb-9a7c-0ea06cf2c6fc.png)
