### PR TITLE
fix: body height

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -37,7 +37,7 @@ export default class MyDocument extends Document {
         </Head>
         <body
           className={classNames([
-            'h-full',
+            'min-h-screen',
             'bg-white dark:bg-blue-900',
             'text-black dark:text-white',
             'transition-theme duration-200 ease',


### PR DESCRIPTION
This PR fixes this behaviour:

![Screenshot from 2021-02-13 09-53-58](https://user-images.githubusercontent.com/12464600/107846104-6ab13680-6de1-11eb-815a-9cdbb921c56b.png)

The problem was that body had a limited height.

Now it applies its min height to be 100vh and let it expand freely:

![Screenshot from 2021-02-13 09-54-32](https://user-images.githubusercontent.com/12464600/107846109-7d2b7000-6de1-11eb-8836-1c8ecd90bd94.png)

## Resource

- https://greggod.medium.com/css-do-not-put-height-100-on-the-body-html-e36bda3551b3